### PR TITLE
[Sikkerhet] Oppdaterer catalog-info.yaml med komponent

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,34 @@
+# nonk8s
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: prodspek_fkb_ar5
+  tags: [public]
+  links:
+    - url: https://github.com/kartverket/prodspek_fkb_ar5
+      title: prodspek_fkb_ar5 på GitHub
+spec:
+  type: service
+  lifecycle: production
+  owner: matrikkel
+  system: matrikkel
+  dependsOn:
+    - resource:default/SKIP
+  providesApis:
+    - prodspek_fkb_ar5-api
+---
+apiVersion: backstage.io/v1alpha1
+kind: API
+metadata:
+  name: prodspek_fkb_ar5-api
+  tags: [public]
+spec:
+  type: openapi
+  lifecycle: production
+  owner: matrikkel
+  system: matrikkel
+  definition: |
+    openapi: "3.0.0"
+    info:
+      title: prodspek_fkb_ar5 API
+    paths:


### PR DESCRIPTION
Denne PRen oppdaterer `catalog-info.yaml` for å gi entiteter til Backstage. Oppretter følgende på komponenten:

- `owner`: `matrikkel`
- `type`: `service`
- `lifecycle`: `production`
- `visibility` (`tags`): `public`

Det er beskrevet [her i Sikkerhetshåndboka](https://kartverket.atlassian.net/wiki/spaces/SIK/pages/732397586/Sikkerhet+i+repoet) hvorfor vi gjør dette.