### PR TITLE
[Sikkerhet] Oppdaterer beskrivelse.yaml fra versjon 1.0 til 3.0 og oppretter catalog-info.yaml

### DIFF
--- a/.sikkerhet/beskrivelse.yaml
+++ b/.sikkerhet/beskrivelse.yaml
@@ -1,2 +1,5 @@
-version: 1.0
-organisasjon: Land
+version: 3.0
+organization: Land
+product: PRODSPEK
+repo_types: [Documentation]
+platforms: []

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,38 @@
+# nonk8s
+apiVersion: "backstage.io/v1alpha1"
+kind: "Component"
+metadata:
+  name: "prodspek_fkb_ar5"
+  tags:
+  - "public"
+spec:
+  type: "documentation"
+  lifecycle: "production"
+  owner: "felles_kartdatabase"
+  system: "standardisering"
+---
+apiVersion: "backstage.io/v1alpha1"
+kind: "Group"
+metadata:
+  name: "security_champion_prodspek_fkb_ar5"
+  title: "Security Champion prodspek_fkb_ar5"
+spec:
+  type: "security_champion"
+  parent: "land_security_champions"
+  members:
+  - "NilsIvarNes"
+  children:
+  - "resource:prodspek_fkb_ar5"
+---
+apiVersion: "backstage.io/v1alpha1"
+kind: "Resource"
+metadata:
+  name: "prodspek_fkb_ar5"
+  links:
+  - url: "https://github.com/kartverket/prodspek_fkb_ar5"
+    title: "prodspek_fkb_ar5 på GitHub"
+spec:
+  type: "repo"
+  owner: "security_champion_prodspek_fkb_ar5"
+  dependencyOf:
+  - "component:prodspek_fkb_ar5"


### PR DESCRIPTION
Denne PRen oppdaterer `.sikkerhet/beskrivelse.yaml` til versjon 3.0. Det innebærer at feltene nå blir på engelsk i stedet for norsk. Følgende felter legges inn:

- `version: 3.0`
- `organization: Land`
- `product: PRODSPEK`
- `repo_types: [Documentation]`
- `platforms: []`

Videre oppdaterer denne PRen `catalog-info.yaml` for å gi entiteter til Backstage.

Det er beskrevet [her i Sikkerhetshåndboka](https://kartverket.atlassian.net/wiki/spaces/SIK/pages/732397586/Sikkerhet+i+repoet) hvorfor vi gjør dette.